### PR TITLE
feat: add jenkins plugin downloader

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = "xyz.jpenilla"
-version = "2.2.1-SNAPSHOT"
+version = "2.2.2-SNAPSHOT"
 description = "Gradle plugins adding run tasks for Minecraft server and proxy software"
 
 repositories {

--- a/plugin/src/main/kotlin/xyz/jpenilla/runtask/pluginsapi/PluginApiDownload.kt
+++ b/plugin/src/main/kotlin/xyz/jpenilla/runtask/pluginsapi/PluginApiDownload.kt
@@ -18,6 +18,7 @@ package xyz.jpenilla.runtask.pluginsapi
 
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
 import xyz.jpenilla.runtask.util.HashingAlgorithm
 import xyz.jpenilla.runtask.util.calculateHash
 import xyz.jpenilla.runtask.util.toHexString
@@ -171,5 +172,48 @@ public abstract class UrlDownload : PluginApiDownload() {
 
   internal fun urlHash(): String {
     return toHexString(url.get().byteInputStream().calculateHash(HashingAlgorithm.SHA1))
+  }
+}
+
+public abstract class JenkinsDownload : PluginApiDownload() {
+
+  @get:Input
+  public abstract val baseUrl: Property<String>
+
+  @get:Input
+  public abstract val job: Property<String>
+
+  @get:Input @get:Optional
+  public abstract val artifactRegex: Property<Regex>
+
+  @get:Input @get:Optional
+  public abstract val build: Property<String>
+
+  override fun toString(): String {
+    return "JenkinsDownload(baseUrl=$baseUrl, job=$job, artifactRegex=$artifactRegex, build=$build)"
+  }
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) {
+      return true
+    }
+    if (javaClass != other?.javaClass) {
+      return false
+    }
+
+    other as JenkinsDownload
+
+    return baseUrl.get() == other.baseUrl.get() &&
+      job.get() == other.job.get() &&
+      artifactRegex.orNull == other.artifactRegex.orNull &&
+      build.orNull == other.build.orNull
+  }
+
+  override fun hashCode(): Int {
+    var result = baseUrl.hashCode()
+    result = 31 * result + job.hashCode()
+    result = 31 * result + artifactRegex.hashCode()
+    result = 31 * result + build.hashCode()
+    return result
   }
 }

--- a/plugin/src/main/kotlin/xyz/jpenilla/runtask/pluginsapi/jenkins/JenkinsPluginProvider.kt
+++ b/plugin/src/main/kotlin/xyz/jpenilla/runtask/pluginsapi/jenkins/JenkinsPluginProvider.kt
@@ -1,0 +1,36 @@
+/*
+ * Run Task Gradle Plugins
+ * Copyright (c) 2023 Jason Penilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package xyz.jpenilla.runtask.pluginsapi.jenkins
+
+import xyz.jpenilla.runtask.pluginsapi.JenkinsDownload
+import xyz.jpenilla.runtask.pluginsapi.PluginApi
+
+/**
+ * [PluginApi] implementation for downloading plugins from Jenkins CI.
+ */
+public interface JenkinsPluginProvider : PluginApi<JenkinsPluginProvider, JenkinsDownload> {
+
+  /**
+   * Add a plugin download.
+   *
+   * @param baseUrl The root url to the jenkins instance
+   * @param job The id of the target job to download the plugin from
+   * @param artifactRegex In case multiple artifacts are provided, a regex to pick the correct artifact
+   * @param build A specific build for the [job] or the lastSuccessfulBuild if none provided
+   */
+  public fun add(baseUrl: String, job: String, artifactRegex: Regex? = null, build: String? = null)
+}

--- a/plugin/src/main/kotlin/xyz/jpenilla/runtask/pluginsapi/jenkins/JenkinsPluginProviderImpl.kt
+++ b/plugin/src/main/kotlin/xyz/jpenilla/runtask/pluginsapi/jenkins/JenkinsPluginProviderImpl.kt
@@ -1,0 +1,49 @@
+/*
+ * Run Task Gradle Plugins
+ * Copyright (c) 2023 Jason Penilla
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package xyz.jpenilla.runtask.pluginsapi.jenkins
+
+import org.gradle.api.model.ObjectFactory
+import org.gradle.kotlin.dsl.newInstance
+import xyz.jpenilla.runtask.pluginsapi.JenkinsDownload
+import javax.inject.Inject
+
+public abstract class JenkinsPluginProviderImpl @Inject constructor(private val name: String, private val objects: ObjectFactory) : JenkinsPluginProvider {
+
+  private val jobs: MutableList<JenkinsDownload> = mutableListOf()
+
+  override fun getName(): String = name
+
+  override fun add(baseUrl: String, job: String, artifactRegex: Regex?, build: String?) {
+    val download = objects.newInstance(JenkinsDownload::class)
+    download.baseUrl.set(baseUrl)
+    download.job.set(job)
+    if (artifactRegex != null) {
+      download.artifactRegex.set(artifactRegex)
+    }
+    if (build != null) {
+      download.build.set(build)
+    }
+    jobs += download
+  }
+
+  override fun copyConfiguration(api: JenkinsPluginProvider) {
+    jobs.addAll(api.downloads)
+  }
+
+  override val downloads: Iterable<JenkinsDownload>
+    get() = jobs
+}

--- a/plugin/src/main/kotlin/xyz/jpenilla/runtask/util/Constants.kt
+++ b/plugin/src/main/kotlin/xyz/jpenilla/runtask/util/Constants.kt
@@ -39,6 +39,10 @@ internal object Constants {
   const val MODRINTH_PLUGIN_DIR = "modrinth"
   const val GITHUB_PLUGIN_DIR = "github"
   const val URL_PLUGIN_DIR = "url"
+  const val JENKINS_PLUGIN_DIR = "jenkins"
+
+  const val JENKINS_LAST_SUCCESSFUL_BUILD = "lastSuccessfulBuild"
+  const val JENKINS_REST_ENDPOINT = "%s/%s/api/json?tree=artifacts[relativePath]"
 
   object Plugins {
     const val SHADOW_PLUGIN_ID = "com.github.johnrengelman.shadow"

--- a/tester/build.gradle.kts
+++ b/tester/build.gradle.kts
@@ -13,6 +13,7 @@ val paperPlugins = runPaper.downloadPluginsSpec {
   github("jpenilla", "MiniMOTD", "v2.0.13", "minimotd-bukkit-2.0.13.jar")
   hangar("squaremap", "1.2.0")
   url("https://download.luckperms.net/1515/bukkit/loader/LuckPerms-Bukkit-5.4.102.jar")
+  jenkins("https://ci.athion.net", "FastAsyncWorldEdit", Regex("Bukkit"))
 }
 
 tasks {


### PR DESCRIPTION
Adds a kinda-easy & standardized way to download Jenkins artifacts instead of doing all the rest calls and delegating to `url()` in the projects itself.

Haven't used Kotlin that much (as most likely visible) - so open for review and modifications ^^