### PR TITLE
Add Discord Plugin downloader

### DIFF
--- a/plugin/src/main/kotlin/xyz/jpenilla/runtask/pluginsapi/DownloadPluginsSpec.kt
+++ b/plugin/src/main/kotlin/xyz/jpenilla/runtask/pluginsapi/DownloadPluginsSpec.kt
@@ -29,6 +29,8 @@ import org.gradle.kotlin.dsl.get
 import org.gradle.kotlin.dsl.named
 import org.gradle.kotlin.dsl.newInstance
 import org.gradle.kotlin.dsl.register
+import xyz.jpenilla.runtask.pluginsapi.discord.DiscordApi
+import xyz.jpenilla.runtask.pluginsapi.discord.DiscordApiImpl
 import xyz.jpenilla.runtask.pluginsapi.github.GitHubApi
 import xyz.jpenilla.runtask.pluginsapi.github.GitHubApiImpl
 import xyz.jpenilla.runtask.pluginsapi.hangar.HangarApi
@@ -67,6 +69,7 @@ public abstract class DownloadPluginsSpec @Inject constructor(
     registry.registerFactory(ModrinthApi::class) { name -> objects.newInstance(ModrinthApiImpl::class, name) }
     registry.registerFactory(GitHubApi::class) { name -> objects.newInstance(GitHubApiImpl::class, name) }
     registry.registerFactory(UrlPluginProvider::class) { name -> objects.newInstance(UrlPluginProviderImpl::class, name) }
+    registry.registerFactory(DiscordApi::class) { name -> objects.newInstance(DiscordApiImpl::class, name) }
 
     register("hangar", HangarApi::class) {
       url.set(HangarApi.DEFAULT_URL)
@@ -76,6 +79,7 @@ public abstract class DownloadPluginsSpec @Inject constructor(
     }
     register("github", GitHubApi::class)
     register("url", UrlPluginProvider::class)
+    register("discord", DiscordApi::class)
   }
 
   /**
@@ -96,6 +100,7 @@ public abstract class DownloadPluginsSpec @Inject constructor(
         is ModrinthApi -> ModrinthApi::class
         is GitHubApi -> GitHubApi::class
         is UrlPluginProvider -> UrlPluginProvider::class
+        is DiscordApi -> DiscordApi::class
         else -> throw IllegalStateException("Unknown PluginApi type: ${api.javaClass.name}")
       }
       configure(name, type) {
@@ -161,6 +166,26 @@ public abstract class DownloadPluginsSpec @Inject constructor(
    */
   public fun github(owner: String, repo: String, tag: String, assetName: String) {
     github.configure { add(owner, repo, tag, assetName) }
+  }
+
+  // discord extensions
+
+  /**
+   * Access to the built-in [DiscordApi].
+   */
+  @get:Internal
+  public val discord: NamedDomainObjectProvider<DiscordApi>
+    get() = named("discord", DiscordApi::class)
+
+  /**
+   * Add a plugin download from a Discord message link.
+   *
+   * @param channelId the Discord channel ID where the message is located
+   * @param messageId the Discord message ID containing the plugin download link
+   * @param token the Discord bot token to use for fetching the message
+   */
+  public fun discord(channelId: String, messageId: String, token: String) {
+    discord.configure { add(channelId, messageId, token) }
   }
 
   // url extensions

--- a/plugin/src/main/kotlin/xyz/jpenilla/runtask/pluginsapi/PluginApiDownload.kt
+++ b/plugin/src/main/kotlin/xyz/jpenilla/runtask/pluginsapi/PluginApiDownload.kt
@@ -21,6 +21,7 @@ import org.gradle.api.tasks.Input
 import xyz.jpenilla.runtask.util.HashingAlgorithm
 import xyz.jpenilla.runtask.util.calculateHash
 import xyz.jpenilla.runtask.util.toHexString
+import kotlin.io.byteInputStream
 
 public sealed class PluginApiDownload
 
@@ -172,4 +173,42 @@ public abstract class UrlDownload : PluginApiDownload() {
   internal fun urlHash(): String {
     return toHexString(url.get().byteInputStream().calculateHash(HashingAlgorithm.SHA1))
   }
+}
+
+public abstract class DiscordApiDownload : PluginApiDownload() {
+  @get:Input
+  public abstract val channelId: Property<String>
+
+  @get:Input
+  public abstract val messageId: Property<String>
+
+  @get:Input
+  public abstract val token: Property<String>
+
+  override fun toString(): String {
+    return "DiscordApiDownload{channelId=${channelId.get()}, messageId=${messageId.get()}, token=${"*".repeat(token.get().length)}}"
+  }
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) {
+      return true
+    }
+    if (javaClass != other?.javaClass) {
+      return false
+    }
+
+    other as DiscordApiDownload
+
+    return channelId.get() == other.channelId.get() &&
+      messageId.get() == other.messageId.get() &&
+      token.get() == other.token.get()
+  }
+
+  override fun hashCode(): Int {
+    var result = channelId.get().hashCode()
+    result = 31 * result + messageId.get().hashCode()
+    result = 31 * result + token.get().hashCode()
+    return result
+  }
+
 }

--- a/plugin/src/main/kotlin/xyz/jpenilla/runtask/pluginsapi/discord/DiscordApi.kt
+++ b/plugin/src/main/kotlin/xyz/jpenilla/runtask/pluginsapi/discord/DiscordApi.kt
@@ -1,0 +1,22 @@
+package xyz.jpenilla.runtask.pluginsapi.discord
+
+import xyz.jpenilla.runtask.pluginsapi.DiscordApiDownload
+import xyz.jpenilla.runtask.pluginsapi.PluginApi
+
+/**
+ * [PluginApi] implementation for Discord message links.
+ */
+public interface DiscordApi : PluginApi<DiscordApi, DiscordApiDownload> {
+  /**
+   * Add a Discord message plugin download.
+   *
+   * @param channelId the ID of the Discord channel containing the message
+   * @param messageId the ID of the Discord message to fetch
+   * @param token the bot token to use for fetching the message
+   */
+  public fun add(
+    channelId: String,
+    messageId: String,
+    token: String
+  )
+}

--- a/plugin/src/main/kotlin/xyz/jpenilla/runtask/pluginsapi/discord/DiscordApiImpl.kt
+++ b/plugin/src/main/kotlin/xyz/jpenilla/runtask/pluginsapi/discord/DiscordApiImpl.kt
@@ -1,0 +1,27 @@
+package xyz.jpenilla.runtask.pluginsapi.discord
+
+import org.gradle.api.model.ObjectFactory
+import org.gradle.kotlin.dsl.newInstance
+import xyz.jpenilla.runtask.pluginsapi.DiscordApiDownload
+import javax.inject.Inject
+
+public abstract class DiscordApiImpl @Inject constructor(private val name: String, private val objects: ObjectFactory) : DiscordApi {
+  private val jobs: MutableList<DiscordApiDownload> = mutableListOf()
+
+  override fun getName(): String = name
+
+  override fun add(channelId: String, messageId: String, token: String) {
+    val job = objects.newInstance(DiscordApiDownload::class)
+    job.channelId.set(channelId)
+    job.messageId.set(messageId)
+    job.token.set(token)
+    jobs += job
+  }
+
+  override fun copyConfiguration(api: DiscordApi) {
+    jobs.addAll(api.downloads)
+  }
+
+  override val downloads: Iterable<DiscordApiDownload>
+    get() = jobs
+}

--- a/plugin/src/main/kotlin/xyz/jpenilla/runtask/util/Constants.kt
+++ b/plugin/src/main/kotlin/xyz/jpenilla/runtask/util/Constants.kt
@@ -39,6 +39,7 @@ internal object Constants {
   const val MODRINTH_PLUGIN_DIR = "modrinth"
   const val GITHUB_PLUGIN_DIR = "github"
   const val URL_PLUGIN_DIR = "url"
+  const val DISCORD_PLUGIN_DIR = "discord"
 
   const val USER_AGENT = "run-task"
 

--- a/tester/build.gradle.kts
+++ b/tester/build.gradle.kts
@@ -12,8 +12,8 @@ val paperPlugins = runPaper.downloadPluginsSpec {
   modrinth("carbon", "6dmNHzy8")
   github("jpenilla", "MiniMOTD", "v2.1.0", "minimotd-bukkit-2.1.0.jar")
   hangar("squaremap", "1.2.3")
-  url("https://download.luckperms.net/1530/bukkit/loader/LuckPerms-Bukkit-5.4.117.jar")
   url("https://download.luckperms.net/1587/bukkit/loader/LuckPerms-Bukkit-5.5.2.jar")
+  discord("1379024292548710400","1379024345845989440", project.property("bot_token") as String)
 }
 
 tasks {

--- a/tester/build.gradle.kts
+++ b/tester/build.gradle.kts
@@ -13,6 +13,7 @@ val paperPlugins = runPaper.downloadPluginsSpec {
   github("jpenilla", "MiniMOTD", "v2.1.0", "minimotd-bukkit-2.1.0.jar")
   hangar("squaremap", "1.2.3")
   url("https://download.luckperms.net/1530/bukkit/loader/LuckPerms-Bukkit-5.4.117.jar")
+  url("https://download.luckperms.net/1587/bukkit/loader/LuckPerms-Bukkit-5.5.2.jar")
 }
 
 tasks {


### PR DESCRIPTION
Add a way to download plugins from a discord message attachment.

I'm not sure if this is actually something that is wanted by others since the authentication works though a bot token which is a bit hacky and requires teams to create a discord bot with [MESSAGE_CONTENT](https://discord.com/developers/docs/events/gateway#message-content-intent) privilege.