### PR TITLE
feat: make the paperweight check more flexible

### DIFF
--- a/plugin/src/main/kotlin/xyz/jpenilla/runpaper/RunPaperPlugin.kt
+++ b/plugin/src/main/kotlin/xyz/jpenilla/runpaper/RunPaperPlugin.kt
@@ -20,6 +20,7 @@ import io.papermc.paperweight.tasks.RemapJar
 import io.papermc.paperweight.userdev.PaperweightUserExtension
 import io.papermc.paperweight.util.constants.DEV_BUNDLE_CONFIG
 import io.papermc.paperweight.util.constants.MOJANG_MAPPED_SERVER_RUNTIME_CONFIG
+import io.papermc.paperweight.util.constants.PAPERWEIGHT_EXTENSION
 import org.gradle.api.Action
 import org.gradle.api.GradleException
 import org.gradle.api.Project
@@ -72,7 +73,7 @@ public abstract class RunPaperPlugin : RunPlugin() {
     }
     runServer.setupPluginJarDetection(target, runExtension)
 
-    target.plugins.withId(Constants.Plugins.PAPERWEIGHT_USERDEV_PLUGIN_ID) {
+    if (target.extensions.findByName(PAPERWEIGHT_EXTENSION) != null) {
       target.setupPaperweightCompat(runServer, runExtension)
     }
 
@@ -98,7 +99,7 @@ public abstract class RunPaperPlugin : RunPlugin() {
   }
 
   override fun findPluginJar(task: TaskProvider<out RunWithPlugins>, project: Project): Provider<RegularFile>? {
-    if (project.plugins.hasPlugin(Constants.Plugins.PAPERWEIGHT_USERDEV_PLUGIN_ID)) {
+    if (project.extensions.findByName(PAPERWEIGHT_EXTENSION) != null) {
       val paperweight = project.extensions.getByType<PaperweightUserExtension>()
       try {
         project.configurations.getByName(DEV_BUNDLE_CONFIG).resolve()

--- a/plugin/src/main/kotlin/xyz/jpenilla/runtask/util/Constants.kt
+++ b/plugin/src/main/kotlin/xyz/jpenilla/runtask/util/Constants.kt
@@ -44,8 +44,6 @@ internal object Constants {
 
   object Plugins {
     const val SHADOW_JAR_TASK_NAME = "shadowJar"
-
-    const val PAPERWEIGHT_USERDEV_PLUGIN_ID = "io.papermc.paperweight.userdev"
     const val PAPERWEIGHT_REOBF_JAR_TASK_NAME = "reobfJar"
   }
 


### PR DESCRIPTION
This change is mainly targeted towards users which use custom paperweight forks needed to build some forks of paper etc, so they can also use the handy devbundle run task, as they cant just switch to paperweight.

The main motivation for this is a plugin project required for another project, that i’m working on which requires hooks in the userdev plugin forcing us to have a fork of it as it modifies the dev bundle’s jar artifact that’s going to be provided as the NMS dependency thus some code that compiles with those modifications can’t run on the `runServer` task’s server instance and requires to be ran by the dev bundle server task, which is currently unavailable for us due to this strict check