### PR TITLE
Add support for downloading latest Modrinth version

### DIFF
--- a/plugin/src/main/kotlin/xyz/jpenilla/runtask/pluginsapi/DownloadPluginsSpec.kt
+++ b/plugin/src/main/kotlin/xyz/jpenilla/runtask/pluginsapi/DownloadPluginsSpec.kt
@@ -142,6 +142,15 @@ public abstract class DownloadPluginsSpec @Inject constructor(
     modrinth.configure { add(id, version) }
   }
 
+  /**
+   * Add a plugin download, downloading the latest available version.
+   *
+   * @param id plugin id on Modrinth
+   */
+  public fun modrinth(id: String) {
+    modrinth.configure { add(id) }
+  }
+
   // github extensions
 
   /**

--- a/plugin/src/main/kotlin/xyz/jpenilla/runtask/pluginsapi/PluginApiDownload.kt
+++ b/plugin/src/main/kotlin/xyz/jpenilla/runtask/pluginsapi/PluginApiDownload.kt
@@ -18,6 +18,7 @@ package xyz.jpenilla.runtask.pluginsapi
 
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
 import xyz.jpenilla.runtask.util.HashingAlgorithm
 import xyz.jpenilla.runtask.util.calculateHash
 import xyz.jpenilla.runtask.util.toHexString
@@ -71,10 +72,11 @@ public abstract class ModrinthApiDownload : PluginApiDownload() {
   public abstract val id: Property<String>
 
   @get:Input
+  @get:Optional
   public abstract val version: Property<String>
 
   override fun toString(): String {
-    return "ModrinthApiDownload{url=${url.get()}, id=${id.get()}, version=${version.get()}}"
+    return "ModrinthApiDownload{url=${url.get()}, id=${id.get()}, version=${version.orNull ?: "latest"}}"
   }
 
   override fun equals(other: Any?): Boolean {
@@ -89,13 +91,13 @@ public abstract class ModrinthApiDownload : PluginApiDownload() {
 
     return url.get() == other.url.get() &&
       id.get() == other.id.get() &&
-      version.get() == other.version.get()
+      version.orNull == other.version.orNull
   }
 
   override fun hashCode(): Int {
     var result = url.get().hashCode()
     result = 31 * result + id.get().hashCode()
-    result = 31 * result + version.get().hashCode()
+    result = 31 * result + version.orNull.hashCode()
     return result
   }
 }

--- a/plugin/src/main/kotlin/xyz/jpenilla/runtask/pluginsapi/PluginDownloadServiceImpl.kt
+++ b/plugin/src/main/kotlin/xyz/jpenilla/runtask/pluginsapi/PluginDownloadServiceImpl.kt
@@ -145,17 +145,37 @@ internal abstract class PluginDownloadServiceImpl : PluginDownloadService {
   private fun resolveModrinthPlugin(progressLoggerFactory: ProgressLoggerFactory, download: ModrinthApiDownload): Path {
     val cacheDir = parameters.cacheDirectory.get().asFile.toPath()
 
-    val apiVersion = download.version.get()
     val apiPlugin = download.id.get()
     val apiUrl = download.url.get()
 
     val provider = manifest.modrinthProviders.computeIfAbsent(download.url.get()) { ModrinthProvider() }
     val plugin = provider.computeIfAbsent(download.id.get()) { PluginVersions() }
+
+    val targetDir = cacheDir.resolve(Constants.MODRINTH_PLUGIN_DIR).resolve(apiPlugin)
+
+    // Resolve the version: if not specified, fetch the latest from the versions list endpoint
+    val apiVersion: String
+    if (!download.version.isPresent) {
+      val latestJsonName = "latest-json"
+      val latestJsonVersion = plugin[latestJsonName] ?: PluginVersion(fileName = "$apiPlugin-latest-versions.json", displayName = "modrinth:$apiPlugin:latest:metadata")
+      val latestJsonFile = targetDir.resolve(latestJsonVersion.fileName)
+      val latestRequestUrl = "$apiUrl/v2/project/$apiPlugin/version"
+      val latestJsonPath = download(
+        DownloadCtx(progressLoggerFactory, apiUrl, latestRequestUrl, targetDir, latestJsonFile, latestJsonVersion, setter = { plugin[latestJsonName] = it }, requireValidJar = false)
+      )
+
+      @OptIn(ExperimentalSerializationApi::class)
+      val versionList = latestJsonPath.inputStream().buffered().use {
+        mapper.decodeFromStream<List<ModrinthVersionListEntry>>(it)
+      }
+      apiVersion = versionList.firstOrNull()?.id ?: error("Could not find any versions for modrinth project $apiPlugin")
+    } else {
+      apiVersion = download.version.get()
+    }
+
     val jsonVersionName = "$apiVersion-json"
     val jsonVersion = plugin[jsonVersionName] ?: PluginVersion(fileName = "$apiPlugin-$apiVersion-info.json", displayName = "modrinth:$apiPlugin:$apiVersion:metadata")
 
-    val targetDir =
-      cacheDir.resolve(Constants.MODRINTH_PLUGIN_DIR).resolve(apiPlugin)
     val jsonFile = targetDir.resolve(jsonVersion.fileName)
 
     val versionRequestUrl = "$apiUrl/v2/project/$apiPlugin/version/$apiVersion"
@@ -364,6 +384,11 @@ private data class ModrinthVersionResponse(
     val hashes: Map<String, String>
   )
 }
+
+@Serializable
+private data class ModrinthVersionListEntry(
+  val id: String
+)
 
 // github types:
 private typealias GitHubProvider = MutableMap<String, GitHubOwner>

--- a/plugin/src/main/kotlin/xyz/jpenilla/runtask/pluginsapi/modrinth/ModrinthApi.kt
+++ b/plugin/src/main/kotlin/xyz/jpenilla/runtask/pluginsapi/modrinth/ModrinthApi.kt
@@ -40,4 +40,11 @@ public interface ModrinthApi : PluginApi<ModrinthApi, ModrinthApiDownload> {
    * @param version plugin version id
    */
   public fun add(id: String, version: String)
+
+  /**
+   * Add a plugin download, downloading the latest available version.
+   *
+   * @param id plugin id on Modrinth
+   */
+  public fun add(id: String)
 }

--- a/plugin/src/main/kotlin/xyz/jpenilla/runtask/pluginsapi/modrinth/ModrinthApiImpl.kt
+++ b/plugin/src/main/kotlin/xyz/jpenilla/runtask/pluginsapi/modrinth/ModrinthApiImpl.kt
@@ -39,6 +39,13 @@ public abstract class ModrinthApiImpl @Inject constructor(private val name: Stri
     jobs.add(job)
   }
 
+  override fun add(id: String) {
+    val job = objects.newInstance(ModrinthApiDownload::class)
+    job.url.set(url.map { it.trimEnd('/') })
+    job.id.set(id)
+    jobs.add(job)
+  }
+
   override fun copyConfiguration(api: ModrinthApi) {
     url.set(api.url)
     jobs.addAll(api.downloads)


### PR DESCRIPTION
This pull request adds support for downloading the latest available version of a plugin from Modrinth when no specific version is provided. It introduces new APIs and logic to handle this use case, and updates the relevant classes to make the plugin version optional.

**Modrinth plugin download improvements:**

* Added a new `modrinth(id: String)` function in `DownloadPluginsSpec` and corresponding `add(id: String)` method in the `ModrinthApi` interface, allowing users to specify only the plugin ID to download the latest version. [[1]](diffhunk://#diff-05ed3d84be96734fc71f7353411a6fa013e68368fde482f846460aea953d81ddR145-R153) [[2]](diffhunk://#diff-4d506837cea17046d1bf4630cd84e67fe225fbd48a1abd3c57e227f868d677a8R43-R49)
* Implemented the new `add(id: String)` method in `ModrinthApiImpl`, creating a `ModrinthApiDownload` job with only the plugin ID set.

**Version handling changes:**

* Made the `version` property in `ModrinthApiDownload` optional, updating its annotations and string representation to reflect when the latest version is used.
* Updated equality and hash code logic in `ModrinthApiDownload` to handle the optional `version` property correctly.

**Download resolution logic:**

* Modified `PluginDownloadServiceImpl` to resolve the latest version from the Modrinth API if no version is specified, fetching the version list and selecting the newest entry. Also added a supporting data class for version list entries. [[1]](diffhunk://#diff-cf425b0bf49fcfa20c6e499887992dd28e09ee96489f36820fa5b66344561299L148-L158) [[2]](diffhunk://#diff-cf425b0bf49fcfa20c6e499887992dd28e09ee96489f36820fa5b66344561299R388-R392)

**Other technical adjustments:**

* Added the `@Optional` annotation import for Gradle tasks.

This was quick and dirty, I literally vibe coded this because I didn't really have time in my hands. If you need a more "human" patch lmk I'll make sure to do that